### PR TITLE
Remove JetBrains `@formatter` comments

### DIFF
--- a/src/auth/handlers.rs
+++ b/src/auth/handlers.rs
@@ -10,7 +10,6 @@ static ACCESS_EXPIRY: usize = 60 * 60 * 100000000;
 static REFRESH_EXPIRY: usize = 24 * 60 * 60 * 100000000;
 
 /// Get tokens for login
-// @formatter:off
 #[utoipa::path(
     post,
     operation_id = "get_tokens",
@@ -21,7 +20,7 @@ static REFRESH_EXPIRY: usize = 24 * 60 * 60 * 100000000;
         (status = 200, description = "Login succeeded", body = TokenView),
         (status = 400, description = "Login failed", body = ApiError)
     )
-)] // @formatter:on
+)]
 pub async fn get_tokens(
     State(store): State<AuthState>,
     Json(request): Json<LoginRequest>,

--- a/src/common/pagination.rs
+++ b/src/common/pagination.rs
@@ -10,10 +10,9 @@ pub struct PaginationParams {
 }
 
 #[derive(Serialize, ToSchema)]
-// @formatter:off
 #[aliases(
     PaginatedTodoView = PaginatedView<TodoView>,
-)] // @formatter:on
+)]
 pub struct PaginatedView<T> {
     pub page: i32,
     pub size: i32,

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -13,11 +13,15 @@ use utoipa_rapidoc::RapiDoc;
 // use utoipa_redoc::{Redoc, Servable};  // Uncomment to enable Redoc
 use utoipa_swagger_ui::SwaggerUi;
 
-use rust_todo_api::{auth::{self, models::JWT_SECRET}, common, common::middlewares::{auth_middleware, AuthState}, todo, user};
+use rust_todo_api::{
+    auth::{self, models::JWT_SECRET},
+    common,
+    common::middlewares::{auth_middleware, AuthState},
+    todo, user,
+};
 
 pub fn build_routes(pool: Pool<Postgres>) -> Router {
     #[derive(OpenApi)]
-    // @formatter:off
     #[openapi(
         paths(
             auth::handlers::get_tokens,
@@ -62,7 +66,6 @@ pub fn build_routes(pool: Pool<Postgres>) -> Router {
             (name = "todo", description = "Todo API")
         )
     )]
-    // @formatter:on
     struct ApiDoc;
 
     struct SecurityAddon;
@@ -110,13 +113,11 @@ pub fn build_routes(pool: Pool<Postgres>) -> Router {
             Router::new()
                 .route(
                     "/",
-                    get(user::handlers::find_user_by_email)
-                        .route_layer(middleware::from_fn_with_state(
-                            auth_state.clone(),
-                            auth_middleware,
-                        )),
+                    get(user::handlers::find_user_by_email).route_layer(
+                        middleware::from_fn_with_state(auth_state.clone(), auth_middleware),
+                    ),
                 )
-                .route("/", post(user::handlers::register_user), ),
+                .route("/", post(user::handlers::register_user)),
         );
 
     Router::new()

--- a/src/todo/handlers.rs
+++ b/src/todo/handlers.rs
@@ -3,6 +3,7 @@ use axum::{
     Json,
 };
 
+use crate::common::pagination::PaginatedView;
 use crate::{
     common::{errors::ApiError, middlewares::AuthState, pagination::PaginationParams},
     todo::{
@@ -10,10 +11,8 @@ use crate::{
         views::{EditTodoRequest, NewTodoRequest, TodoView},
     },
 };
-use crate::common::pagination::PaginatedView;
 
 /// Create todo
-// @formatter:off
 #[utoipa::path(
     post,
     operation_id = "create_todo",
@@ -26,7 +25,7 @@ use crate::common::pagination::PaginatedView;
         (status = 500, description = "Todo creation failed", body = ApiError)
     ),
     security(("api_key" = []))
-)] // @formatter:on
+)]
 pub async fn create_todo(
     State(state): State<AuthState>,
     Json(todo): Json<NewTodoRequest>,
@@ -40,7 +39,6 @@ pub async fn create_todo(
 }
 
 /// Find todos
-// @formatter:off
 #[utoipa::path(
     get,
     operation_id = "find_todos",
@@ -53,7 +51,7 @@ pub async fn create_todo(
         (status = 500, description = "Todos not found", body = ApiError)
     ),
     security(("api_key" = []))
-)] // @formatter:on
+)]
 pub async fn find_todos(
     State(state): State<AuthState>,
     Query(query): Query<PaginationParams>,
@@ -63,18 +61,16 @@ pub async fn find_todos(
     let todos = todo_service::find_todos(state.pool, page, size).await;
 
     match todos {
-        Ok(todos) => Ok(Json(
-            PaginatedView {
-                page,
-                size,
-                items: todos.into_iter().map(TodoView::from).collect(),
-            })),
+        Ok(todos) => Ok(Json(PaginatedView {
+            page,
+            size,
+            items: todos.into_iter().map(TodoView::from).collect(),
+        })),
         Err(e) => Err(ApiError::new_internal(e.to_string())),
     }
 }
 
 /// Find todo by id
-// @formatter:off
 #[utoipa::path(
     get,
     operation_id = "find_todo_by_id",
@@ -90,7 +86,7 @@ pub async fn find_todos(
         (status = 500, description = "Todo not found", body = ApiError)
     ),
     security(("api_key" = []))
-)] // @formatter:on
+)]
 pub async fn find_todo_by_id(
     State(state): State<AuthState>,
     Path(id): Path<i32>,
@@ -110,7 +106,6 @@ pub async fn find_todo_by_id(
 }
 
 /// Edit todo by id
-// @formatter:off
 #[utoipa::path(
     put,
     operation_id = "edit_todo_by_id",
@@ -127,7 +122,7 @@ pub async fn find_todo_by_id(
         (status = 500, description = "Todo not found", body = ApiError)
     ),
     security(("api_key" = []))
-)] // @formatter:on
+)]
 pub async fn edit_todo_by_id(
     State(state): State<AuthState>,
     Path(id): Path<i32>,
@@ -148,7 +143,6 @@ pub async fn edit_todo_by_id(
 }
 
 /// Delete todo by id
-// @formatter:off
 #[utoipa::path(
     delete,
     operation_id = "delete_todo_by_id",
@@ -163,7 +157,7 @@ pub async fn edit_todo_by_id(
         (status = 500, description = "Todo not found", body = ApiError)
     ),
     security(("api_key" = []))
-)] // @formatter:on
+)]
 pub async fn delete_todo_by_id(
     State(state): State<AuthState>,
     Path(id): Path<i32>,

--- a/src/user/handlers.rs
+++ b/src/user/handlers.rs
@@ -13,7 +13,6 @@ use crate::{
 };
 
 /// Register user
-// @formatter:off
 #[utoipa::path(
     post,
     operation_id = "register_user",
@@ -26,7 +25,7 @@ use crate::{
         (status = 409, description = "User already exists", body = ApiError),
         (status = 500, description = "User creation failed", body = ApiError)
     )
-)] // @formatter:on
+)]
 pub async fn register_user(
     State(state): State<AuthState>,
     Json(request): Json<NewUserRequest>,
@@ -56,7 +55,6 @@ pub struct FindUserQuery {
 }
 
 /// Find user by email
-// @formatter:off
 #[utoipa::path(
     get,
     operation_id = "find_user_by_email",
@@ -69,7 +67,7 @@ pub struct FindUserQuery {
         (status = 404, description = "User not found", body = ApiError),
     ),
     security(("api_key" = []))
-)] // @formatter:on
+)]
 pub async fn find_user_by_email(
     State(state): State<AuthState>,
     Query(query): Query<FindUserQuery>,


### PR DESCRIPTION
With `rustfmt` option enabled in IntelliJ, `@formatter` comments to disable formatting codes inside macro can all be deleted. (It doesn't format with the option turned on)

![image](https://github.com/litsynp/rust-axum-todo-api/assets/42485462/fbd9c7e8-d2de-49a6-a578-7fb99b61afc0)
